### PR TITLE
Change _normalizeTypeKey to defer normalization to the container

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1751,7 +1751,9 @@ Store = Ember.Object.extend({
     @return {String} if the adapter can generate one, an ID
   */
   _normalizeTypeKey: function(key) {
-    return camelize(singularize(key));
+    //return camelize(singularize(key));
+    // defer normalization to the container
+    return this.container.normalize(key);
   }
 });
 

--- a/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
@@ -1,4 +1,4 @@
-var env, store, adapter, Post, Comment, SuperUser;
+var env, store, adapter, Post, Comment, SuperUser, EmberCliUser;
 var passedUrl, passedVerb, passedHash;
 var run = Ember.run;
 
@@ -16,12 +16,17 @@ module("integration/adapter/rest_adapter - REST Adapter", {
       name: DS.attr("string")
     });
 
+    EmberCliUser = DS.Model.extend({
+      name: DS.attr("string")
+    });
+
     SuperUser = DS.Model.extend();
 
     env = setupStore({
       post: Post,
       comment: Comment,
       superUser: SuperUser,
+      'ember-cli-user': EmberCliUser,
       adapter: DS.RESTAdapter
     });
 
@@ -165,6 +170,22 @@ test("create - an empty payload is a basic success if an id was specified", func
 
       equal(post.get('isDirty'), false, "the post isn't dirty anymore");
       equal(post.get('name'), "The Parley Letter", "the post was updated");
+    }));
+  });
+});
+
+test("create dasherized model name is a basic success", function() {
+  ajaxResponse();
+  var emberCliUser;
+
+  run(function() {
+    emberCliUser = store.createRecord('ember-cli-user', { name: "The Parley Letter" });
+    emberCliUser.save().then(async(function(post) {
+      equal(passedUrl, "/emberCliUsers");
+      equal(passedVerb, "POST");
+
+      equal(post.get('isDirty'), false, "the ember-cli-user isn't dirty anymore");
+      equal(post.get('name'), "The Parley Letter", "the ember-cli-user was updated");
     }));
   });
 });

--- a/packages/ember-data/tests/unit/store/create_record_test.js
+++ b/packages/ember-data/tests/unit/store/create_record_test.js
@@ -42,7 +42,7 @@ test("creating a record by camel-case string finds the model", function() {
   });
 
   equal(record.get('foo'), attributes.foo, "The record is created");
-  equal(store.modelFor('someThing').typeKey, 'someThing');
+  equal(store.modelFor('someThing').typeKey, 'some-thing');
 });
 
 test("creating a record by dasherize string finds the model", function() {
@@ -54,7 +54,7 @@ test("creating a record by dasherize string finds the model", function() {
   });
 
   equal(record.get('foo'), attributes.foo, "The record is created");
-  equal(store.modelFor('some-thing').typeKey, 'someThing');
+  equal(store.modelFor('some-thing').typeKey, 'some-thing');
 });
 
 module("unit/store/createRecord - Store with models by camelCase", {


### PR DESCRIPTION
There are some failing tests and some additional work to do.
The issue is that in unit tests for ember-cli for models with dashes and
when using an adapter, the model's typeKey is normalized to camelCase
but `store.modelFor(camelCasedName)` will fail.

For example, with a model class 'ssh-key', create a record using the
string 'ssh-key'. This will work fine because the store will call `modelFor('ssh-key')`. This returns the correct model factory and it has the side effect of setting `typeKey` on that factory to `sshKey`.

Later, when saving that record, the store will call `Adapter.createRecord` which starts out by calling
`store.serializerFor(type.typeKey)`. The store's `serializerFor` method passes this same typeKey (`sshKey`) to `store.modelFor`. But `store.modelFor('sshKey')` will fail because it will call `container.lookupFactory('model:sshKey')` and find nothing.

The call to `lookupFactory('model:sshKey')` will fail in the test because the test's container's `normalizeFullName` method is this:

```
function (fullName){
  return fullName;
}
```

When running an ember-cli normally (or when running an acceptance test), the container uses the ember-cli resolver and its `normalizeFullName` method becomes this:

```
function (fullName) {
        if (resolver.normalize) {
          return resolver.normalize(fullName);
        } else {
          Ember.deprecate('The Resolver should now provide a \'normalize\' function', false);
          return fullName;
        }
      }
```

In this case, `resolver.normalize` will return the same value (`"model:ssh-key"`) when it is passed either `"model:sshKey"` or `"model:ssh-key"`, so the app's `store.modelFor('sshKey')` and `store.modelFor('ssh-key')` return the same thing.

There's a [sample ember-cli app](https://github.com/bantic/ember-data-dasherize-test-failure-example) showing this behavior. The important parts are in [this commit](https://github.com/bantic/ember-data-dasherize-test-failure-example/commit/5a6b9c91760e7b467d5975b9124060aa975d97f1). The failing test code looks like this:

```
  import {
    moduleForModel,
    test
  } from 'ember-qunit';
  import Ember from 'ember';

  moduleForModel('ssh-key', 'SshKey', {
    // Specify the other units that are required for this test.
    needs: ['adapter:application']
  });

  test('it can be looked up', function() {
    var store = this.store();

    var sshKey;

    Ember.run(function(){
      sshKey = store.createRecord('ssh-key');
    });

    return Ember.run(function(){
      return sshKey.save();
    });
  });
```

Screenshot of the failing test in the ember-cli app:
![testtests tests 2015-01-26 18-44-41](https://cloud.githubusercontent.com/assets/2023/5910736/96ee4f1e-a58b-11e4-89a5-d0fc3538fe53.jpg)

cc @mixonic
